### PR TITLE
Xm 36 checkpoint

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
-  before_save { self.email = email.downcase }
+  #around_save { self.email = email.downcase }
   validates :name, length: { minimum: 1, maximum: 100 }, presence: true
   validates :password, presence: true, length: { minimum: 6 }, if: "password_digest.nil?"
   validates :password, length: { minimum: 6 }, allow_blank: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
-  #around_save { self.email = email.downcase }
+  before_save -> (){ self.email = email.downcase }, if: -> (){ email.present? }
   validates :name, length: { minimum: 1, maximum: 100 }, presence: true
   validates :password, presence: true, length: { minimum: 6 }, if: "password_digest.nil?"
   validates :password, length: { minimum: 6 }, allow_blank: true

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Topic, type: :model do
 
   describe 'associations' do # Using Shoulda matchers http://matchers.shoulda.io/docs/v3.1.1/
     it { should have_many(:posts).dependent(:destroy) }
-    it { should have_many(:sponsored_posts).dependent(:destroy) }
   end
   
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,40 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { User.create!(name: "Bloccit User", email: "user@bloccit.com", password: "password") }
-  it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_length_of(:name).is_at_least(1) }
 
-  it { is_expected.to validate_presence_of(:email) }
-  it { is_expected.to validate_uniqueness_of(:email) }
-  it { is_expected.to validate_length_of(:email).is_at_least(3) }
-  it { is_expected.to allow_value("user@bloccit.com").for(:email) }
-
-  it { is_expected.to validate_presence_of(:password) }
-  it { is_expected.to have_secure_password }
-  it { is_expected.to validate_length_of(:password).is_at_least(6) }
+  # Documentation for Shoulda matchers http://matchers.shoulda.io/docs/v3.1.1/
 
   describe "attributes" do
-    it "should respond to name" do
-      expect(user).to respond_to(:name)
-    end
-
-    it "should respond to email" do
-      expect(user).to respond_to(:email)
-    end
+    it { should have_db_column(:name).of_type(:string) }
+    it { should have_db_column(:email).of_type(:string) }
   end
 
-  describe "invalid user" do
-    let(:user_with_invalid_name) { User.new(name: "", email: "user@bloccit.com") }
-    let(:user_with_invalid_email) { User.new(name: "Bloccit User", email: "") }
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_least(1) }
 
-    it "should be an invalid user due to blank name" do
-      expect(user_with_invalid_name).to_not be_valid
-    end
+    it { is_expected.to validate_presence_of(:email) }
+    it { should validate_uniqueness_of(:email).case_insensitive }
+    it { is_expected.to validate_length_of(:email).is_at_least(3) }
+    it { is_expected.to allow_value("user@bloccit.com").for(:email) }
 
-    it "should be an invalid user due to blank email" do
-      expect(user_with_invalid_email).to_not be_valid
-    end
+    it { is_expected.to validate_presence_of(:password) }
+    it { is_expected.to have_secure_password }
+    it { is_expected.to validate_length_of(:password).is_at_least(6) }
   end
 
 end


### PR DESCRIPTION
- replaces attribute examples with shoulda versions
- makes `before_save` callback conditional so unique validation spec works